### PR TITLE
made plexpy api path root configurable, it's not always at /plexpy/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ There are multiple settings you must configure!
 This file needs multiple values. Most importantly your Tautulli IP, port and API key. I made this using HTTP, if you use HTTPS you have to modify the API.
 
 <b>api/get_stats_2020.php</b><br>
-This file needs to know the ID of your movie and show library. It only supports two libraries. The ID can be found in your url when you open the library on the Tautulli website.
+This file needs to know the ID of your movie and show library. It only supports two libraries. The ID can be found in your url when you open the library on the Tautulli website. If your Tautulli API is rooted somewhere other than at `/plexpy` you can override that here as well.
 
 If you are lucky, it could be functional now.
 <br><br><br>

--- a/api/get_stats_2020.php
+++ b/api/get_stats_2020.php
@@ -5,13 +5,14 @@ $config = json_decode(file_get_contents("../config.json"));
 //CONFIGURE THESE!
 $library_id_movies = 1;
 $library_id_shows = 2;
+$plexpy_path_root = "/plexpy";
 //
 
 $p_email = $data->p_email;
 $p_email = htmlspecialchars($p_email);
 $id = "fail";
 
-$url = "http://" . $config->ip . ":" . $config->plexpy_port . "/plexpy/api/v2?apikey=" . $config->plexpy_apikey . "&cmd=get_users";
+$url = "http://" . $config->ip . ":" . $config->plexpy_port . $plexpy_path_root . "/api/v2?apikey=" . $config->plexpy_apikey . "&cmd=get_users";
 $response = json_decode(file_get_contents($url));
 
 for ($i = 0; $i < count($response->response->data); $i++) {
@@ -27,7 +28,7 @@ if ($id == "fail") {
 }
 
 // Name
-$url = "http://" . $config->ip . ":" . $config->plexpy_port . "/plexpy/api/v2?apikey=" . $config->plexpy_apikey . "&cmd=get_user_ips&user_id=" . $id;
+$url = "http://" . $config->ip . ":" . $config->plexpy_port . $plexpy_path_root . "/api/v2?apikey=" . $config->plexpy_apikey . "&cmd=get_user_ips&user_id=" . $id;
 $response = json_decode(file_get_contents($url));
 $name = $response->response->data->data[0]->friendly_name;
 
@@ -37,7 +38,7 @@ $logg = "\n" . $date . " - " . $name . " (" . $p_email . ")";
 file_put_contents("log.txt", $logg, FILE_APPEND);
 
 //MOVIES
-$url = "http://" . $config->ip . ":" . $config->plexpy_port . "/plexpy/api/v2?apikey=" . $config->plexpy_apikey . "&cmd=get_history&user_id=" . $id . "&section_id=" . $library_id_movies . "&order_column=full_title&order_dir=asc&length=10000";
+$url = "http://" . $config->ip . ":" . $config->plexpy_port . $plexpy_path_root .  "/api/v2?apikey=" . $config->plexpy_apikey . "&cmd=get_history&user_id=" . $id . "&section_id=" . $library_id_movies . "&order_column=full_title&order_dir=asc&length=10000";
 $response = json_decode(file_get_contents($url));
 $array = $response->response->data->data;
 $movies = array();
@@ -99,7 +100,7 @@ $movie_percent_average = 0;
 }
 
 //SHOWS
-$url = "http://" . $config->ip . ":" . $config->plexpy_port . "/plexpy/api/v2?apikey=" . $config->plexpy_apikey . "&cmd=get_history&user_id=" . $id . "&section_id=" . $library_id_shows . "&order_column=full_title&order_dir=asc&length=10000";
+$url = "http://" . $config->ip . ":" . $config->plexpy_port . $plexpy_path_root . "/api/v2?apikey=" . $config->plexpy_apikey . "&cmd=get_history&user_id=" . $id . "&section_id=" . $library_id_shows . "&order_column=full_title&order_dir=asc&length=10000";
 $response = json_decode(file_get_contents($url));
 $array = $response->response->data->data;
 $shows = array();
@@ -134,7 +135,7 @@ array_multisort($duration, SORT_DESC, $shows);
 
 //SHOW BUDDIES
 if(count($shows) > 0){
-$url = "http://" . $config->ip . ":" . $config->plexpy_port . "/plexpy/api/v2?apikey=" . $config->plexpy_apikey . "&cmd=get_history&section_id=" . $library_id_shows . "&order_column=full_title&order_dir=asc&length=10000&search=" . urlencode($shows[0]["title"]);
+$url = "http://" . $config->ip . ":" . $config->plexpy_port . $plexpy_path_root . "/api/v2?apikey=" . $config->plexpy_apikey . "&cmd=get_history&section_id=" . $library_id_shows . "&order_column=full_title&order_dir=asc&length=10000&search=" . urlencode($shows[0]["title"]);
 $response = json_decode(file_get_contents($url));
 $array = $response->response->data->data;
 $top_show_users = array();
@@ -190,12 +191,12 @@ if(count($top_show_users) > 1) {
 }
 
 //GET USERS LAST 365
-$url = "http://" . $config->ip . ":" . $config->plexpy_port . "/plexpy/api/v2?apikey=" . $config->plexpy_apikey . "&cmd=get_plays_by_top_10_users&time_range=365&y_axis=duration";
+$url = "http://" . $config->ip . ":" . $config->plexpy_port . $plexpy_path_root ."/api/v2?apikey=" . $config->plexpy_apikey . "&cmd=get_plays_by_top_10_users&time_range=365&y_axis=duration";
 $response = json_decode(file_get_contents($url));
 $top_users = $response->response->data->categories;
 
 //GET TOP MOVIES AND SHOWS
-$url = "http://" . $config->ip . ":" . $config->plexpy_port . "/plexpy/api/v2?apikey=" . $config->plexpy_apikey . "&cmd=get_home_stats&time_range=365&stats_type=duration&grouping=1&stats_count=10";
+$url = "http://" . $config->ip . ":" . $config->plexpy_port . $plexpy_path_root ."/api/v2?apikey=" . $config->plexpy_apikey . "&cmd=get_home_stats&time_range=365&stats_type=duration&grouping=1&stats_count=10";
 $response = json_decode(file_get_contents($url));
 $top_10_movies = array();
 $top_10_shows = array();


### PR DESCRIPTION
I have Tautalli installed in a docker, and the API is not rooted at `/plexpy`. This slight refactoring allows for that to be reconfigured.